### PR TITLE
Faster training on TPU

### DIFF
--- a/Training/notebooks/MNIST_on_TPU.ipynb
+++ b/Training/notebooks/MNIST_on_TPU.ipynb
@@ -1,0 +1,638 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "MNIST_on_TPU.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "TPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/hrishikeshmane/MNIST_DRAW/blob/training-on-tpu-colab/Training/notebooks/MNIST_on_TPU.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TpKPMXvC0qt9",
+        "colab_type": "text"
+      },
+      "source": [
+        "We Use GPUs for training our DNNs and CNNs models faster but TPUs can be way faster than GPUs while training your models.\n",
+        "\n",
+        "Unfortunately, training on TPU is a bit different than training on CPUs and GPUs. So here's a small demo for training a CNN on TPU for MNIST dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VLw4dtANxV65",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Install Tensorflow 1.12.0 and make sure you ***reset*** the environment before executing further cells\n",
+        "\n",
+        "### Also Change runtime type to **TPU**\n",
+        "      Runtime -> Change runtime type -> Select TPU from Hardware Accelerator"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UrRWOtVEkA0c",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 629
+        },
+        "outputId": "37c72cd9-bba0-461c-a33d-6d18c30084de"
+      },
+      "source": [
+        "!pip install tensorflow==1.12.0"
+      ],
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting tensorflow==1.12.0\n",
+            "  Using cached https://files.pythonhosted.org/packages/22/cc/ca70b78087015d21c5f3f93694107f34ebccb3be9624385a911d4b52ecef/tensorflow-1.12.0-cp36-cp36m-manylinux1_x86_64.whl\n",
+            "Requirement already satisfied: grpcio>=1.8.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.15.0)\n",
+            "Collecting tensorboard<1.13.0,>=1.12.0\n",
+            "  Using cached https://files.pythonhosted.org/packages/07/53/8d32ce9471c18f8d99028b7cef2e5b39ea8765bd7ef250ca05b490880971/tensorboard-1.12.2-py3-none-any.whl\n",
+            "Requirement already satisfied: protobuf>=3.6.1 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (3.10.0)\n",
+            "Requirement already satisfied: keras-preprocessing>=1.0.5 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.1.0)\n",
+            "Requirement already satisfied: keras-applications>=1.0.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.0.8)\n",
+            "Requirement already satisfied: six>=1.10.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.12.0)\n",
+            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.1.0)\n",
+            "Requirement already satisfied: wheel>=0.26 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (0.33.6)\n",
+            "Requirement already satisfied: astor>=0.6.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (0.8.0)\n",
+            "Requirement already satisfied: numpy>=1.13.3 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (1.16.5)\n",
+            "Requirement already satisfied: gast>=0.2.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (0.2.2)\n",
+            "Requirement already satisfied: absl-py>=0.1.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow==1.12.0) (0.8.1)\n",
+            "Requirement already satisfied: werkzeug>=0.11.10 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.13.0,>=1.12.0->tensorflow==1.12.0) (0.16.0)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.13.0,>=1.12.0->tensorflow==1.12.0) (3.1.1)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from protobuf>=3.6.1->tensorflow==1.12.0) (41.4.0)\n",
+            "Requirement already satisfied: h5py in /usr/local/lib/python3.6/dist-packages (from keras-applications>=1.0.6->tensorflow==1.12.0) (2.8.0)\n",
+            "Installing collected packages: tensorboard, tensorflow\n",
+            "  Found existing installation: tensorboard 1.11.0\n",
+            "    Uninstalling tensorboard-1.11.0:\n",
+            "      Successfully uninstalled tensorboard-1.11.0\n",
+            "  Found existing installation: tensorflow 1.12.0rc1\n",
+            "    Uninstalling tensorflow-1.12.0rc1:\n",
+            "      Successfully uninstalled tensorflow-1.12.0rc1\n",
+            "Successfully installed tensorboard-1.12.2 tensorflow-1.12.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.colab-display-data+json": {
+              "pip_warning": {
+                "packages": [
+                  "tensorflow"
+                ]
+              }
+            }
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "h6TvyMawOK_Q",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import numpy as np\n",
+        "import tensorflow as tf\n",
+        "import time\n",
+        "import os\n",
+        "\n",
+        "import tensorflow.keras\n",
+        "from tensorflow.keras.datasets import mnist, fashion_mnist\n",
+        "from tensorflow.keras.models import Sequential, Model\n",
+        "from tensorflow.keras.layers import Dense, Dropout, Flatten,Input\n",
+        "from tensorflow.keras.layers import Conv2D, MaxPooling2D\n",
+        "from tensorflow.keras import backend as K"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "guB6PFEmk7tt",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "outputId": "1642c5b4-7fdb-4c14-92d1-923e59215679"
+      },
+      "source": [
+        "print(tf.__version__)"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1.12.0\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vPWNJCc_gGgj",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "outputId": "8e96359f-faeb-4f53-bd30-a856b1f52d1c"
+      },
+      "source": [
+        "# check for TPU\n",
+        "try:\n",
+        "  device_name = os.environ['COLAB_TPU_ADDR']\n",
+        "  TPU_ADDRESS = 'grpc://' + device_name\n",
+        "  print('Found TPU at: {}'.format(TPU_ADDRESS))\n",
+        "\n",
+        "except KeyError:\n",
+        "  print('TPU not found')"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Found TPU at: grpc://10.13.189.242:8470\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RpLYFHU_y3yl",
+        "colab_type": "text"
+      },
+      "source": [
+        "Note that batch size here is significant higher than what we use on CPU or GPU. One of the perks of using TPU for fast training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SlEzwfnNgLzc",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "batch_size = 1280\n",
+        "num_classes = 10\n",
+        "epochs = 5\n",
+        "learning_rate = 0.001\n",
+        "\n",
+        "img_rows, img_cols = 28, 28\n",
+        "\n",
+        "# download and load the data \n",
+        "(x_train, y_train),(x_test, y_test) = mnist.load_data()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hD4gO2qIgQAe",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# expand the channel dimension\n",
+        "x_train = x_train.reshape(x_train.shape[0], img_rows, img_cols, 1)\n",
+        "x_test = x_test.reshape(x_test.shape[0], img_rows, img_cols, 1)\n",
+        "input_shape = (img_rows, img_cols, 1)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "nS6cqe6mqXUD",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 73
+        },
+        "outputId": "707da6c4-4f4e-4c65-d42a-8a0b31c166ae"
+      },
+      "source": [
+        "# normalize the value of pixels from [0, 255] to [0, 1] for further process\n",
+        "x_train = x_train.astype('float32')\n",
+        "x_test = x_test.astype('float32')\n",
+        "x_train /= 255\n",
+        "x_test /= 255\n",
+        "print('x_train shape:', x_train.shape)\n",
+        "print(x_train.shape[0], 'train samples')\n",
+        "print(x_test.shape[0], 'test samples')"
+      ],
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "x_train shape: (60000, 28, 28, 1)\n",
+            "60000 train samples\n",
+            "10000 test samples\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "es619YVRgWxy",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# convert class vectors to binary class matrics\n",
+        "y_train = tf.keras.utils.to_categorical(y_train, num_classes)\n",
+        "y_test = tf.keras.utils.to_categorical(y_test, num_classes)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dqKl-zc3iTUS",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "def train_input_fn(batch_size=1280):\n",
+        "  # Convert entries to a data set. \n",
+        "  dataset = tf.data.Dataset.from_tensor_slices((x_train,y_train)) \n",
+        "  dataset = dataset.shuffle(1000).repeat().batch(batch_size, drop_remainder=True)\n",
+        "  return dataset\n",
+        "\n",
+        "\n",
+        "def test_input_fn(batch_size=1280):\n",
+        "  # Convert entries to a data set.\n",
+        "  dataset = tf.data.Dataset.from_tensor_slices((x_test,y_test)) \n",
+        "  dataset = dataset.shuffle(1000).repeat().batch(batch_size, drop_remainder=True)\n",
+        "  return dataset"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xzJcR6sKiTRW",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "Inp = tf.keras.Input(\n",
+        "    name='input', shape=input_shape, batch_size=batch_size, dtype=tf.float32)\n",
+        "\n",
+        "x = Conv2D(32, kernel_size=(3, 3), activation='relu',name = 'Conv_01')(Inp)\n",
+        "x = MaxPooling2D(pool_size=(2, 2),name = 'MaxPool_01')(x)\n",
+        "x = Conv2D(64, (3, 3), activation='relu',name = 'Conv_02')(x)\n",
+        "x = MaxPooling2D(pool_size=(2, 2),name = 'MaxPool_02')(x)\n",
+        "x = Conv2D(64, (3, 3), activation='relu',name = 'Conv_03')(x)\n",
+        "x = Flatten(name = 'Flatten_01')(x)\n",
+        "x = Dense(64, activation='relu',name = 'Dense_01')(x)\n",
+        "x = Dropout(0.5,name = 'Dropout_02')(x)\n",
+        "\n",
+        "output = Dense(num_classes, activation='softmax',name = 'Dense_02')(x)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "itqNZVPDiTOu",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model = tf.keras.Model(inputs=[Inp], outputs=[output])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "L7adCJVTiTMS",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model.compile(\n",
+        "    optimizer='adam',\n",
+        "    loss='categorical_crossentropy',\n",
+        "    metrics=['acc'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "y341HlHwiTJZ",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 390
+        },
+        "outputId": "6c47db01-314c-4a1f-ea24-364f13db3886"
+      },
+      "source": [
+        "# model conversion\n",
+        "tpu_model = tf.contrib.tpu.keras_to_tpu_model(\n",
+        "    model,\n",
+        "    strategy=tf.contrib.tpu.TPUDistributionStrategy(\n",
+        "        tf.contrib.cluster_resolver.TPUClusterResolver(TPU_ADDRESS)))"
+      ],
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "INFO:tensorflow:Querying Tensorflow master (b'grpc://10.13.189.242:8470') for TPU system metadata.\n",
+            "INFO:tensorflow:Found TPU system:\n",
+            "INFO:tensorflow:*** Num TPU Cores: 8\n",
+            "INFO:tensorflow:*** Num TPU Workers: 1\n",
+            "INFO:tensorflow:*** Num TPU Cores Per Worker: 8\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:CPU:0, CPU, -1, 13512207836376184998)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:XLA_CPU:0, XLA_CPU, 17179869184, 12748413851137428604)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:0, TPU, 17179869184, 5999868185035103339)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:1, TPU, 17179869184, 10259209721630297050)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:2, TPU, 17179869184, 1292729078200471710)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:3, TPU, 17179869184, 16021991460053556819)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:4, TPU, 17179869184, 2787384851371185018)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:5, TPU, 17179869184, 1105022244968911406)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:6, TPU, 17179869184, 15962318447927812840)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU:7, TPU, 17179869184, 8498679807608159605)\n",
+            "INFO:tensorflow:*** Available Device: _DeviceAttributes(/job:worker/replica:0/task:0/device:TPU_SYSTEM:0, TPU_SYSTEM, 8589934592, 4857794915875002600)\n",
+            "WARNING:tensorflow:tpu_model (from tensorflow.contrib.tpu.python.tpu.keras_support) is experimental and may change or be removed at any time, and without warning.\n",
+            "INFO:tensorflow:Cloning Adam {'lr': 0.0010000000474974513, 'beta_1': 0.8999999761581421, 'beta_2': 0.9990000128746033, 'decay': 0.0, 'epsilon': 1e-07, 'amsgrad': False}\n",
+            "INFO:tensorflow:Cloning Adam {'lr': 0.0010000000474974513, 'beta_1': 0.8999999761581421, 'beta_2': 0.9990000128746033, 'decay': 0.0, 'epsilon': 1e-07, 'amsgrad': False}\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8o9cUS4Zjbvy",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 518
+        },
+        "outputId": "1e645c8a-514a-4d28-e3ed-20c79d09a464"
+      },
+      "source": [
+        "tpu_model.summary()"
+      ],
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "_________________________________________________________________\n",
+            "Layer (type)                 Output Shape              Param #   \n",
+            "=================================================================\n",
+            "input (InputLayer)           (1280, 28, 28, 1)         0         \n",
+            "_________________________________________________________________\n",
+            "Conv_01 (Conv2D)             (1280, 26, 26, 32)        320       \n",
+            "_________________________________________________________________\n",
+            "MaxPool_01 (MaxPooling2D)    (1280, 13, 13, 32)        0         \n",
+            "_________________________________________________________________\n",
+            "Conv_02 (Conv2D)             (1280, 11, 11, 64)        18496     \n",
+            "_________________________________________________________________\n",
+            "MaxPool_02 (MaxPooling2D)    (1280, 5, 5, 64)          0         \n",
+            "_________________________________________________________________\n",
+            "Conv_03 (Conv2D)             (1280, 3, 3, 64)          36928     \n",
+            "_________________________________________________________________\n",
+            "Flatten_01 (Flatten)         (1280, 576)               0         \n",
+            "_________________________________________________________________\n",
+            "Dense_01 (Dense)             (1280, 64)                36928     \n",
+            "_________________________________________________________________\n",
+            "Dropout_02 (Dropout)         (1280, 64)                0         \n",
+            "_________________________________________________________________\n",
+            "Dense_02 (Dense)             (1280, 10)                650       \n",
+            "=================================================================\n",
+            "Total params: 93,322\n",
+            "Trainable params: 93,322\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CTX7QEKrjbsm",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 687
+        },
+        "outputId": "2878e832-56c5-433c-ed04-bc6733dabaec"
+      },
+      "source": [
+        "# train\n",
+        "tpu_model.fit(\n",
+        "  train_input_fn,\n",
+        "  steps_per_epoch = 60000//batch_size,\n",
+        "  epochs=10,\n",
+        ")"
+      ],
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/10\n",
+            "INFO:tensorflow:New input shapes; (re-)compiling: mode=train (# of cores 8), [TensorSpec(shape=(1280,), dtype=tf.int32, name=None), TensorSpec(shape=(1280, 28, 28, 1), dtype=tf.float32, name=None), TensorSpec(shape=(1280, 10), dtype=tf.float32, name=None)]\n",
+            "INFO:tensorflow:Overriding default placeholder.\n",
+            "INFO:tensorflow:Cloning Adam {'lr': 0.0010000000474974513, 'beta_1': 0.8999999761581421, 'beta_2': 0.9990000128746033, 'decay': 0.0, 'epsilon': 1e-07, 'amsgrad': False}\n",
+            "INFO:tensorflow:Remapping placeholder for input\n",
+            "INFO:tensorflow:KerasCrossShard: <tensorflow.python.keras.optimizers.Adam object at 0x7f4d7e4b6978> []\n",
+            "INFO:tensorflow:Started compiling\n",
+            "INFO:tensorflow:Finished compiling. Time elapsed: 3.4039101600646973 secs\n",
+            "INFO:tensorflow:Setting weights on TPU model.\n",
+            "INFO:tensorflow:CPU -> TPU lr: 0.0010000000474974513 {0.001}\n",
+            "INFO:tensorflow:CPU -> TPU beta_1: 0.8999999761581421 {0.9}\n",
+            "INFO:tensorflow:CPU -> TPU beta_2: 0.9990000128746033 {0.999}\n",
+            "INFO:tensorflow:CPU -> TPU decay: 0.0 {0.0}\n",
+            "WARNING:tensorflow:Cannot update non-variable config: epsilon\n",
+            "WARNING:tensorflow:Cannot update non-variable config: amsgrad\n",
+            "46/46 [==============================] - 14s 303ms/step - loss: 1.0542 - acc: 0.6688\n",
+            "Epoch 2/10\n",
+            "46/46 [==============================] - 2s 41ms/step - loss: 0.2500 - acc: 0.9275\n",
+            "Epoch 3/10\n",
+            "46/46 [==============================] - 2s 41ms/step - loss: 0.1463 - acc: 0.9580\n",
+            "Epoch 4/10\n",
+            "46/46 [==============================] - 2s 37ms/step - loss: 0.1075 - acc: 0.9693\n",
+            "Epoch 5/10\n",
+            "46/46 [==============================] - 2s 37ms/step - loss: 0.0866 - acc: 0.9756\n",
+            "Epoch 6/10\n",
+            "46/46 [==============================] - 2s 38ms/step - loss: 0.0726 - acc: 0.9792\n",
+            "Epoch 7/10\n",
+            "46/46 [==============================] - 2s 42ms/step - loss: 0.0616 - acc: 0.9824\n",
+            "Epoch 8/10\n",
+            "46/46 [==============================] - 2s 44ms/step - loss: 0.0545 - acc: 0.9843\n",
+            "Epoch 9/10\n",
+            "46/46 [==============================] - 2s 43ms/step - loss: 0.0479 - acc: 0.9863\n",
+            "Epoch 10/10\n",
+            "46/46 [==============================] - 2s 43ms/step - loss: 0.0436 - acc: 0.9876\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tensorflow.python.keras.callbacks.History at 0x7f4d7eba5da0>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 29
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZKM2PzIsw0zc",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 204
+        },
+        "outputId": "39b93921-637c-4af3-e587-6eff5359b708"
+      },
+      "source": [
+        "# evaluate\n",
+        "tpu_model.evaluate(test_input_fn, steps = 100)"
+      ],
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "INFO:tensorflow:New input shapes; (re-)compiling: mode=eval (# of cores 8), [TensorSpec(shape=(1280,), dtype=tf.int32, name=None), TensorSpec(shape=(1280, 28, 28, 1), dtype=tf.float32, name=None), TensorSpec(shape=(1280, 10), dtype=tf.float32, name=None)]\n",
+            "INFO:tensorflow:Overriding default placeholder.\n",
+            "INFO:tensorflow:Cloning Adam {'lr': 0.0010000000474974513, 'beta_1': 0.8999999761581421, 'beta_2': 0.9990000128746033, 'decay': 0.0, 'epsilon': 1e-07, 'amsgrad': False}\n",
+            "INFO:tensorflow:Remapping placeholder for input\n",
+            "INFO:tensorflow:KerasCrossShard: <tensorflow.python.keras.optimizers.Adam object at 0x7f4d7ca91d68> []\n",
+            "INFO:tensorflow:Started compiling\n",
+            "INFO:tensorflow:Finished compiling. Time elapsed: 2.658039093017578 secs\n",
+            "100/100 [==============================] - 8s 80ms/step\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[0.02362885305657983, 0.9914785271883011]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DRlg-9gljbqR",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 184
+        },
+        "outputId": "6cf432ea-3054-4463-8701-03bcbd43664d"
+      },
+      "source": [
+        "tpu_model.save_weights('MNIST_TPU.h5', overwrite=True)"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "INFO:tensorflow:Copying TPU weights to the CPU\n",
+            "INFO:tensorflow:TPU -> CPU lr: 0.0010000000474974513\n",
+            "INFO:tensorflow:TPU -> CPU beta_1: 0.8999999761581421\n",
+            "INFO:tensorflow:TPU -> CPU beta_2: 0.9990000128746033\n",
+            "INFO:tensorflow:TPU -> CPU decay: 0.0\n",
+            "INFO:tensorflow:TPU -> CPU epsilon: 1e-07\n",
+            "WARNING:tensorflow:Cannot update non-variable config: epsilon\n",
+            "INFO:tensorflow:TPU -> CPU amsgrad: False\n",
+            "WARNING:tensorflow:Cannot update non-variable config: amsgrad\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qn3aP_ekjbZK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
We use GPUs for training our DNNs and CNNs models faster but TPUs can be way faster than GPUs while training your models.
Unfortunately, training on TPU is a bit different than training on CPUs and GPUs. So here's a small demo for training a CNN on TPU for the MNIST dataset.

